### PR TITLE
Add accent color for sections title frames

### DIFF
--- a/beamercolorthemematerial.sty
+++ b/beamercolorthemematerial.sty
@@ -280,6 +280,7 @@
 \hypersetup{linkcolor=primary}
 \setbeamercolor{section in toc}{fg=primary}
 \setbeamercolor{subsection in toc}{fg=primary}
+\setbeamercolor{part title}{fg=accent}
 
 
 \mode


### PR DESCRIPTION
Hi,

When we create a section title frame, the title have a default color.
I think we should use the accent color for the text.
The second choice would have been the primary color but I think the accent color is nicer here.

BTW, Thank you for your amazing Beamer theme :smile: 